### PR TITLE
fix(build): update keycloak version dependency to fix NoSuchMethodError on 21.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,9 +13,9 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
-		<keycloak.version>16.0.0</keycloak.version>
+		<keycloak.version>21.0.2</keycloak.version>
 		<maven-shade.version>3.2.4</maven-shade.version>
-		<package.version>1.0.0-rc.6</package.version>
+		<package.version>1.0.0-rc.7</package.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
> ERROR [org.keycloak.services.error.KeycloakErrorHandler] (executor-thread-29) Uncaught server error: java.lang.NoSuchMethodError: 'org.jboss.resteasy.spi.HttpRequest org.keycloak.authentication.AuthenticationFlowContext.getHttpRequest()'