### PR TITLE
OTP form issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
-		<keycloak.version>24.0.3</keycloak.version>
+		<keycloak.version>22.0.5</keycloak.version>
 		<maven-shade.version>3.2.4</maven-shade.version>
 		<package.version>2.1.0</package.version>
 	</properties>

--- a/pom.xml
+++ b/pom.xml
@@ -13,9 +13,9 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
-		<keycloak.version>22.0.5</keycloak.version>
+		<keycloak.version>24.0.3</keycloak.version>
 		<maven-shade.version>3.2.4</maven-shade.version>
-		<package.version>2.0.0</package.version>
+		<package.version>2.1.0</package.version>
 	</properties>
 
 	<dependencies>

--- a/src/main/java/com/weare5stones/keycloak/authenticators/emailotp/EmailOTPAuthenticator.java
+++ b/src/main/java/com/weare5stones/keycloak/authenticators/emailotp/EmailOTPAuthenticator.java
@@ -115,23 +115,18 @@ public class EmailOTPAuthenticator implements Authenticator {
         context.success();
       }
     } else {
-      // invalid
-      AuthenticationExecutionModel execution = context.getExecution();
-      if (execution.isRequired()) {
-        context.failureChallenge(AuthenticationFlowError.INVALID_CREDENTIALS,
-            context.form().setAttribute("realm", context.getRealm())
-                .setError("emailTOTPCodeInvalid").createForm(TOTP_FORM));
-      } else if (execution.isConditional() || execution.isAlternative()) {
-        if (remainingAttempts > 0) {
-          // decrement the remaining attempts
-          authSession.setAuthNote(AUTH_NOTE_REMAINING_RETRIES, Integer.toString(remainingAttempts - 1));
-          // display the error message
+      // Code is invalid
+      remainingAttempts--;
+      authSession.setAuthNote(AUTH_NOTE_REMAINING_RETRIES, Integer.toString(remainingAttempts));
+
+      if (remainingAttempts > 0) {
+          // Inform user of the remaining attempts
           context.failureChallenge(AuthenticationFlowError.INVALID_CREDENTIALS,
-              context.form().setAttribute("realm", context.getRealm())
-                .setError("emailTOTPCodeInvalid", remainingAttemptsStr).createForm(TOTP_FORM));
-        } else {
-          context.attempted();
-        }
+                  context.form().setAttribute("realm", context.getRealm())
+                          .setError("emailTOTPCodeInvalid", Integer.toString(remainingAttempts)).createForm(TOTP_FORM));
+      } else {
+          // Reset login
+          context.resetFlow();
       }
     }
   }

--- a/src/main/resources/theme-resources/messages/messages_de.properties
+++ b/src/main/resources/theme-resources/messages/messages_de.properties
@@ -3,6 +3,7 @@ emailTOTPBodyHtml=Ihr Email Code lautet: <br/> <h2>{1}</h2></div> <br/> Sie ist 
 
 emailTOTPFormTitle=Email Code
 emailTOTPFormLabel=Code
+resendEmail=E-Mail zur\u00Fcksenden
 emailTOTPFormInstruction=Geben Sie den Code ein, den wir an Ihr Ger\u00E4t gesendet haben.
 
 emailTOTPCodeExpired=Die G\u00FCltigkeit des Codes ist abgelaufen.

--- a/src/main/resources/theme-resources/messages/messages_en.properties
+++ b/src/main/resources/theme-resources/messages/messages_en.properties
@@ -3,6 +3,7 @@ emailTOTPBodyHtml=Your temporary login code is: <br/> <h2>{1}</h2></div> <br/> T
 
 emailTOTPFormTitle=Temporary Login Code
 emailTOTPFormLabel=Code
+resendEmail=Resend email
 emailTOTPFormInstruction=Enter the code we sent to your email address.
 
 emailTOTPCodeExpired=The code has expired.

--- a/src/main/resources/theme-resources/templates/totp-form.ftl
+++ b/src/main/resources/theme-resources/templates/totp-form.ftl
@@ -13,14 +13,14 @@
 				</div>
 			</div>
 			<div class="${properties.kcFormGroupClass!} ${properties.kcFormSettingClass!}">
-				<div id="kc-form-options" class="${properties.kcFormOptionsClass!}">
-					<div class="${properties.kcFormOptionsWrapperClass!}">
-						<span><a href="${url.loginUrl}">${kcSanitize(msg("backToLogin"))?no_esc}</a></span>
-					</div>
-				</div>
-
 				<div id="kc-form-buttons" class="${properties.kcFormButtonsClass!}">
 					<input class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}" type="submit" value="${msg("doSubmit")}"/>
+				</div>
+
+				<div id="kc-form-options" class="${properties.kcFormOptionsClass!}">
+					<div class="${properties.kcFormOptionsWrapperClass!}">
+						<span><a href="${url.loginUrl}">${msg("resendEmail")}</a></span>
+					</div>
 				</div>
 			</div>
 		</form>


### PR DESCRIPTION
Fix https://github.com/5-stones/keycloak-email-otp/issues/6

1. The number of tries is incorrectly displayed as "{0}" in case user submits incorrect code.
2. User can submit an incorrect code infinite number of times regardless of the value set for "Max Retries".
3. The label "<< Back to Login" should be revised to something like "Resend Email", as it triggers the email resend action instead of restarting the login process (like pressing on the icon "Restart login" above on the right side of user's email).

Tested on Keycloak version 22.0.5 and 24.0.3. Screenshot of the new form:

![Screenshot 2024-04-24 at 16 02 46](https://github.com/5-stones/keycloak-email-otp/assets/9354023/02e296c3-253e-4687-b519-393071b94a19)
