### PR TITLE
fix(translations): remove erroneous s in emailTOTPBody

### DIFF
--- a/src/main/resources/theme-resources/messages/messages_en.properties
+++ b/src/main/resources/theme-resources/messages/messages_en.properties
@@ -1,4 +1,4 @@
-emailTOTPBody=Your temporary login code is {1}s and is valid for {2} minutes.
+emailTOTPBody=Your temporary login code is {1} and is valid for {2} minutes.
 emailTOTPBodyHtml=Your temporary login code is: <br/> <h2>{1}</h2></div> <br/> This code is valid for {2} minutes.
 
 emailTOTPFormTitle=Temporary Login Code


### PR DESCRIPTION
Before this change, there was an additional "s" included right after the TOTP code.
This could be mistaken as part of the TOTP code, which is wrong.