### PR TITLE
feat(messages_es): add spanish translation in theme messages resources folder

### DIFF
--- a/src/main/resources/theme-resources/messages/messages_es.properties
+++ b/src/main/resources/theme-resources/messages/messages_es.properties
@@ -1,0 +1,19 @@
+emailTOTPBody=Tu código de inicio de sesión temporal es {1} y será válido durante {2} minutos..
+emailTOTPBodyHtml=Tu código de inicio de sesión temporal es: <br/> <h2>{1}</h2></div> <br/> Este código es válido durante {2} minutos.
+
+emailTOTPFormTitle=Código temporal de inicio de sesión 
+emailTOTPFormLabel=Código
+resendEmail=Reenviar correo electrónico
+emailTOTPFormInstruction=Introduce el código que enviamos a tu dirección de correo electrónico.
+
+emailTOTPCodeExpired=El código ha expirado.
+emailTOTPCodeInvalid=Código inválido, inténtalo de nuevo. Te quedan {0} intentos.
+emailTOTPEmailNotSent=Lo sentimos, algo salió mal al intentar enviar el correo electrónico. Por favor, inténtalo de nuevo.
+emailTOTPResendRetriesLimitReached=Lo sentimos, pero has alcanzado el número máximo de intentos para reenviar el correo electrónico OTP
+
+emailotp-authenticator-display-name=Enviar un código por correo electrónico
+emailotp-authenticator-help-text=Inicia sesión introduciendo un código de acceso temporal que te enviaremos por correo electrónico.
+
+doResend=Reenviar correo electrónico
+otpMailSentAgain=Se ha enviado de nuevo el correo electrónico con el código OTP; por favor, revise su bandeja de entrada.
+


### PR DESCRIPTION
This PR introduces Spanish language support by adding a new messages_es.properties file. This ensures that the plugin's UI components, error messages, and email templates are properly localized for Spanish-speaking users.

**Changes:**

- Created src/main/resources/theme-resources/messages/messages_es.properties.
- Translated all existing message keys from the default English bundle.
- Verified that the encoding is set to UTF-8 to properly handle special characters (accents, tildes).